### PR TITLE
Fix date debug format for Windows

### DIFF
--- a/main.py
+++ b/main.py
@@ -436,7 +436,7 @@ def compute_daily_ratios(dates, weekday_ratios):
             r *= 1.10
             reason += ", mar_boost*1.10"
 
-        logging.debug("%s: %s", d.strftime('%-m/%-d'), reason)
+        logging.debug("%s: %s", f"{d.month}/{d.day}", reason)
         ratios.append(r)
         prev_ratio = r
 


### PR DESCRIPTION
## Summary
- avoid unsupported `strftime('%-m/%-d')` format on Windows

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_684a3fa07540832da4b9ea79a1050c29