### PR TITLE
Fix breakfast revenue rounding precision

### DIFF
--- a/main.py
+++ b/main.py
@@ -639,7 +639,7 @@ def process(settings: Settings):
         df['喫食数'] = adjust_to_total(base_count, breakfast_count, 1).round().astype(int)
 
         # breakfast revenue rounding step determined by monthly budget precision
-        base_revenue = (df['喫食数'] * settings.breakfast_price).round()
+        base_revenue = df['喫食数'] * settings.breakfast_price
         step_breakfast = get_rounding_step(row['朝食売上'])
         df['朝食売上'] = adjust_to_total(base_revenue, row['朝食売上'], step_breakfast).round().astype(int)
 


### PR DESCRIPTION
## Summary
- ensure breakfast revenue rounding uses monthly budget precision

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_684a62122660832da18d1e63ce5578f5