### PR TITLE
Fix non-terminating loop in adjust_to_total_with_cap

### DIFF
--- a/main.py
+++ b/main.py
@@ -297,6 +297,13 @@ def adjust_to_total_with_cap(series: pd.Series, target: float, step: int, cap: f
         if len(base) > 0:
             base.iloc[-1] += diff
         return base
+    if abs(diff) >= step * 10 and len(base) > 0:
+        logging.warning(
+            "adjust_to_total_with_cap: diff %.2f too large, forcing into last element",
+            diff,
+        )
+        base.iloc[-1] += diff
+        return base
 
     free_mask = base < cap if diff > 0 else base > 0
     if free_mask.any():


### PR DESCRIPTION
## Summary
- avoid endless loop in `adjust_to_total_with_cap` when diff is too large

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_684d2bece338832da419df20bc41c75f