### PR TITLE
Fix undefined variable usage for rounding steps

### DIFF
--- a/main.py
+++ b/main.py
@@ -660,6 +660,9 @@ def process(settings: Settings):
             step = step_revenue if m == '宿泊売上' else 1
             df[m] = allocate_from_ratios(dates, daily_ratios.values, row[m], step).values
 
+        step_fb_other = get_rounding_step_smart(row['料飲その他売上'])
+        step_other = get_rounding_step_smart(row['その他売上'])
+
         # ensure no zero allocations for key metrics
         for col, step, total_val in [
             ('宿泊売上', step_revenue, row['宿泊売上']),


### PR DESCRIPTION
## Summary
- define `step_fb_other` and `step_other` before they are used

## Testing
- `python -m py_compile main.py`
- `pip install pandas openpyxl jpholiday --quiet` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_684f522b80ec832da0944486686a1527