### PR TITLE
Add configurable DOR limits

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -5,4 +5,6 @@ breakfast_price = 1091
 weight_prev_year = 0.7
 weight_2_3m = 0.1
 weight_recent = 0.2
+dor_min = 1.0
+dor_max = 2.5
 


### PR DESCRIPTION
## Summary
- support new Settings fields `dor_min` and `dor_max`
- load/save DOR limits from `settings.ini`
- apply DOR limit logic only when limit > 0
- add GUI entries for DOR min/max and a "DOR上限なし" checkbox
- update default configuration

## Testing
- `python -m py_compile main.py`
- `python - <<'EOF'
import main
main.process(main.load_settings())
print('done')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684f6230be90832dae3091a123602295